### PR TITLE
added new environment for westend (testing)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,3 +87,13 @@ canvas:
   rules:
     - if: '$CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_REF_NAME =~ /^fv.*/'
   <<:                              *deploy-k8s
+
+westend:
+  stage:                           deploy
+  environment:
+    name:                          westend
+  tags:
+    - kubernetes-parity-build
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_REF_NAME =~ /^fv.*/'
+  <<:                              *deploy-k8s

--- a/kubernetes/faucetbot/westend-values.yaml
+++ b/kubernetes/faucetbot/westend-values.yaml
@@ -7,7 +7,8 @@ secret:
 
 config:
   INJECTED_TYPES: '{}'
-  MATRIX_BOT_USER_ID: '@westend_faucet:matrix.org'
+  # MATRIX_BOT_USER_ID: '@westend_faucet:matrix.org'
+  MATRIX_BOT_USER_ID: '@test_bot_faucet:matrix.org'
   RPC_ENDPOINT: 'wss://westend-rpc.polkadot.io/'
   DRIP_AMOUNT: 0.5
   NETWORK_DECIMALS: 12


### PR DESCRIPTION
deploys an 2nd instance of the faucet hooked up to westen faucet address / westend-rpc node and a test matrix room. this is for testing the deployment und should not interfere with the existing westend-faucet.