### PR TITLE
Log on api reconnect and timeout and new prometheus metric

### DIFF
--- a/src/server/ErrorCounter.ts
+++ b/src/server/ErrorCounter.ts
@@ -1,18 +1,25 @@
+type CounterType = 'rpcTimeout' | 'other'
 
 class ErrorCounter {
   private static instance: ErrorCounter;
-  #counter: number;
+  #counter: Record<CounterType, number>
 
   private constructor () {
-    this.#counter = 0;
+    this.#counter = { other: 0, rpcTimeout: 0 };
   }
 
-  public getValue = () => {
-    return this.#counter;
+  public getValue = (type: CounterType) => {
+    return this.#counter[type];
   }
 
-  public plusOne = () => {
-    this.#counter += 1;
+  public plusOne = (type: CounterType) => {
+    this.#counter[type] += 1;
+  }
+
+  public total = (): number => {
+    return Object.values(this.#counter).reduce((prev, curr) => {
+      return prev + curr;
+    }, 0);
   }
 
   public static getInstance (): ErrorCounter {

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -14,6 +14,15 @@ const url = getEnvVariable('RPC_ENDPOINT', envVars) as string;
 const injectedTypes = JSON.parse(getEnvVariable('INJECTED_TYPES', envVars) as string) as Record<string, string>;
 const decimals = getEnvVariable('NETWORK_DECIMALS', envVars) as number;
 
+const rpcTimeout = (service: string) => {
+  const timeout = 10000;
+  return setTimeout(() => {
+    // log an error in console and in prometheus if the timeout is reached
+    console.error(`Oops, ${service} took more than ${timeout}ms to answer`);
+    errorCounter.plusOne('rpcTimeout');
+  }, timeout);
+};
+
 export default class Actions {
   api: ApiPromise | undefined;
   account: KeyringPair | undefined;
@@ -26,7 +35,7 @@ export default class Actions {
       this.account = keyring.addFromMnemonic(mnemonic);
     }).catch(e => {
       logger.error(e);
-      errorCounter.plusOne();
+      errorCounter.plusOne('other');
     });
   }
 
@@ -34,9 +43,12 @@ export default class Actions {
     const provider = new WsProvider(url);
     try {
       this.api = await ApiPromise.create({ provider, types: injectedTypes });
+      this.api.on('connected', () => {
+        console.log('--> api reconnected!');
+      });
     } catch (e) {
       logger.error(e);
-      errorCounter.plusOne();
+      errorCounter.plusOne('other');
     }
   }
 
@@ -52,11 +64,17 @@ export default class Actions {
 
       const dripAmount = Number(amount) * 10 ** decimals;
       const transfer = this.api.tx.balances.transfer(address, dripAmount);
+
+      // start a counter and log a timeout error if we didn't get an answer in time
+      const dripTimeout = rpcTimeout('drip');
       const hash = await transfer.signAndSend(this.account);
+
+      // we got and answer reset the timeout
+      clearTimeout(dripTimeout);
       return hash.toHex();
     } catch (e) {
       logger.error('An error occured when sending tokens', e);
-      errorCounter.plusOne();
+      errorCounter.plusOne('other');
       return null;
     }
   }
@@ -70,7 +88,14 @@ export default class Actions {
       throw new Error('account not ready');
     }
 
+    // start a counter and log a timeout error if we didn't get an answer in time
+    const balanceTimeout = rpcTimeout('balance');
+
     const { data: balances } = await this.api.query.system.account(this.account.address);
+
+    // we got and answer reset the timeout
+    clearTimeout(balanceTimeout);
+
     return balances.free.toString();
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -26,7 +26,10 @@ app.get('/health', (_, res) => {
 app.get('/metrics', (_, res) => {
   res.end(`# HELP errors_total The total amount of errors logged on the faucet backend
 # TYPE errors_total counter
-errors_total ${errorCounter.getValue()}
+errors_total ${errorCounter.total()}
+# HELP errors_rpc_timeout The total amount of timeout errors between the faucet backend and the rpc node
+# TYPE errors_rpc_timeout counter
+errors_rpc_timeout ${errorCounter.getValue('rpcTimeout')}
 `
   );
 });
@@ -40,7 +43,7 @@ const createAndApplyActions = (): void => {
       res.send(balance);
     } catch (e) {
       logger.error(e);
-      errorCounter.plusOne();
+      errorCounter.plusOne('other');
     }
   });
 
@@ -64,7 +67,7 @@ const createAndApplyActions = (): void => {
         storage.saveData(sender, address)
           .catch((e) => {
             logger.error(e);
-            errorCounter.plusOne();
+            errorCounter.plusOne('other');
           });
 
         const hash = await actions.sendTokens(address, amount);
@@ -72,7 +75,7 @@ const createAndApplyActions = (): void => {
       }
     } catch (e) {
       logger.error(e);
-      errorCounter.plusOne();
+      errorCounter.plusOne('other');
     }
   });
 };


### PR DESCRIPTION
Example of the prometheus metrics now:
```
# HELP errors_total The total amount of errors logged on the faucet backend
# TYPE errors_total counter
errors_total 1
# HELP errors_rpc_timeout The total amount of timeout errors between the faucet backend and the rpc node
# TYPE errors_rpc_timeout counter
errors_rpc_timeout 1
```