### PR TITLE
gitlab-ci no longer supports docker

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,11 +2,9 @@ image:                             paritytech/kubetools:helm3
 
 variables:
   KUBE_NAMESPACE:                  "faucetbots"
-  CI_REGISTRY:                     "paritytech"
+  CI_REGISTRY:                     "docker.io/paritytech"
   DOCKER_TAG:                      '$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA'
   GIT_STRATEGY:                    fetch
-  DOCKER_DRIVER:                   overlay2
-  DOCKER_HOST:                     tcp://localhost:2375
 
 stages:
   - dockerize
@@ -17,10 +15,8 @@ stages:
 .build_and_push:                   &build_and_push
   tags:
     - kubernetes-parity-build
-  image:                           docker:git
+  image:                           quay.io/buildah/stable
   interruptible:                   true
-  services:
-    - docker:dind
   script:
     # create the docker image name
     - DOCKERFILE="Dockerfile-$(echo "${CI_JOB_NAME}" | awk -F'-' '{print $NF}')"
@@ -28,14 +24,14 @@ stages:
     # set 'BUILDKIT_INLINE_CACHE' so generated images can be used for caching subsequently
     - export BUILD_ARGS="$BUILD_ARGS --build-arg BUILDKIT_INLINE_CACHE=1"
     # pull latest image used as cache to speed up the docker build process
-    - docker pull $DOCKER_IMAGE:latest || true
+    - buildah pull $DOCKER_IMAGE:latest || true
     # login to the docker registry
-    - echo "$Docker_Hub_Pass_Parity" | docker login -u "$Docker_Hub_User_Parity" --password-stdin
+    - echo "$Docker_Hub_Pass_Parity" | buildah login -u "$Docker_Hub_User_Parity" --password-stdin
     # do: docker build
-    - eval "docker build --cache-from $DOCKER_IMAGE:latest -t" "$DOCKER_IMAGE:$DOCKER_TAG" "-t $DOCKER_IMAGE:latest" "$BUILD_ARGS"  "-f $DOCKERFILE" "."
+    - eval "buildah bud --cache-from $DOCKER_IMAGE:latest -t" "$DOCKER_IMAGE:$DOCKER_TAG" "-t $DOCKER_IMAGE:latest" "$BUILD_ARGS"  "-f $DOCKERFILE" "."
     # do: docker push
-    - docker push "$DOCKER_IMAGE:latest"
-    - docker push "$DOCKER_IMAGE:$DOCKER_TAG"
+    - buildah push "$DOCKER_IMAGE:latest"
+    - buildah push "$DOCKER_IMAGE:$DOCKER_TAG"
 
 faucet-bot:
   stage:                           dockerize

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ stages:
     # do: docker build
     - eval "buildah bud --format=docker --cache-from $DOCKER_IMAGE:latest -t" "$DOCKER_IMAGE:$DOCKER_TAG" "-t $DOCKER_IMAGE:latest" "$BUILD_ARGS"  "-f $DOCKERFILE" "."
     # do: docker push
-    - buildah push "$DOCKER_IMAGE:latest"
+    - buildah push --format=v2s2 "$DOCKER_IMAGE:latest"
     - buildah push --format=v2s2 "$DOCKER_IMAGE:$DOCKER_TAG"
 
 faucet-bot:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ stages:
     - eval "buildah bud --format=docker --cache-from $DOCKER_IMAGE:latest -t" "$DOCKER_IMAGE:$DOCKER_TAG" "-t $DOCKER_IMAGE:latest" "$BUILD_ARGS"  "-f $DOCKERFILE" "."
     # do: docker push
     - buildah push "$DOCKER_IMAGE:latest"
-    - buildah push "$DOCKER_IMAGE:$DOCKER_TAG"
+    - buildah push --format=v2s2 "$DOCKER_IMAGE:$DOCKER_TAG"
 
 faucet-bot:
   stage:                           dockerize

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ stages:
     # login to the docker registry
     - echo "$Docker_Hub_Pass_Parity" | buildah login -u "$Docker_Hub_User_Parity" --password-stdin  docker.io
     # do: docker build
-    - eval "buildah bud --cache-from $DOCKER_IMAGE:latest -t" "$DOCKER_IMAGE:$DOCKER_TAG" "-t $DOCKER_IMAGE:latest" "$BUILD_ARGS"  "-f $DOCKERFILE" "."
+    - eval "buildah bud --format=docker --cache-from $DOCKER_IMAGE:latest -t" "$DOCKER_IMAGE:$DOCKER_TAG" "-t $DOCKER_IMAGE:latest" "$BUILD_ARGS"  "-f $DOCKERFILE" "."
     # do: docker push
     - buildah push "$DOCKER_IMAGE:latest"
     - buildah push "$DOCKER_IMAGE:$DOCKER_TAG"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ stages:
     # pull latest image used as cache to speed up the docker build process
     - buildah pull $DOCKER_IMAGE:latest || true
     # login to the docker registry
-    - echo "$Docker_Hub_Pass_Parity" | buildah login -u "$Docker_Hub_User_Parity" --password-stdin
+    - echo "$Docker_Hub_Pass_Parity" | buildah login -u "$Docker_Hub_User_Parity" --password-stdin  docker.io
     # do: docker build
     - eval "buildah bud --cache-from $DOCKER_IMAGE:latest -t" "$DOCKER_IMAGE:$DOCKER_TAG" "-t $DOCKER_IMAGE:latest" "$BUILD_ARGS"  "-f $DOCKERFILE" "."
     # do: docker push


### PR DESCRIPTION
use `buildah` instead of `docker` to create docker images.