### PR TITLE
Double the drip, but once per day

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ NETWORK_UNIT #optional - token unit for the network
 example:
 ```bash
 BACKEND_URL="http://localhost:5555"
-DRIP_AMOUNT=5
+DRIP_AMOUNT=10
 MATRIX_ACCESS_TOKEN="ThisIsNotARealAccessToken"
 MATRIX_BOT_USER_ID="@test_bot_faucet:matrix.org"
 NETWORK_DECIMALS=12
@@ -52,7 +52,7 @@ NETWORK_UNIT="CAN"
 
 0. Create an account for your MATRIX_BOT_USER_ID at https://matrix.org/, login and retrieve MATRIX_ACCESS_TOKEN in `Settigns -> Help and about -> click to reveal`
 
-1. Create a *chainName-values.yaml* file and define all non default variables. Secret variables (MATRIX_ACCESS_TOKEN & FAUCET_ACCOUNT_MNEMONIC) you need to supply externally 
+1. Create a *chainName-values.yaml* file and define all non default variables. Secret variables (MATRIX_ACCESS_TOKEN & FAUCET_ACCOUNT_MNEMONIC) you need to supply externally
 via CI / command line / ...
 
 2. Create a new CI-Job / Environment in *.gitlab-ci.yml* file and add Secrets (in clear / non-base64 encoded format) to `gitlab -> CI/CD Settings -> Secret Variables`).
@@ -61,18 +61,18 @@ via CI / command line / ...
 
 
 
-### Example Helm usage: 
+### Example Helm usage:
 
 ```
 helm template westend . \
- --values ./westend-values.yaml \ 
+ --values ./westend-values.yaml \
  --set server.secret.FAUCET_ACCOUNT_MNEMONIC='ich und du muellers esel das bist du' \
  --set server.image.dockerTag=latest \
  --set bot.secret.MATRIX_ACCESS_TOKEN='asdf-not-a-secret-asfd'
 
 helm -n faucetbots ls --all
 
-helm -n faucetbots rollback canvas 2 
+helm -n faucetbots rollback canvas 2
 ```
 
 ### Misc:

--- a/kubernetes/faucetbot/values.yaml
+++ b/kubernetes/faucetbot/values.yaml
@@ -42,7 +42,7 @@ bot:
     #full url for the bot to reach the backend
     BACKEND_URL: "http://localhost:5555"
     #default amount of token to send
-    DRIP_AMOUNT: 5
+    DRIP_AMOUNT: 10
     #decimal amount for the network
     NETWORK_DECIMALS: 12
     #token unit for the network

--- a/kubernetes/faucetbot/westend-values.yaml
+++ b/kubernetes/faucetbot/westend-values.yaml
@@ -17,5 +17,5 @@ bot:
     MATRIX_ACCESS_TOKEN: from-gitlab-ci-secret-variables
   config:
     MATRIX_BOT_USER_ID: '@westend-faucet:matrix.org'
-    DRIP_AMOUNT: 0.5
+    DRIP_AMOUNT: 1
     NETWORK_UNIT: WND

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -117,7 +117,7 @@ bot.on('Room.timeline', (event: mSDK.MatrixEvent) => {
       }
 
       if (res.data === 'LIMIT') {
-        sendMessage(roomId, `${sender} has reached their daily quota. Only request twice per 24 hours.`);
+        sendMessage(roomId, `${sender} has reached their daily quota. Only request once per day.`);
         return;
       }
 

--- a/src/server/storage.ts
+++ b/src/server/storage.ts
@@ -38,7 +38,7 @@ export default class Storage {
     });
   }
 
-  async isValid (username: string, addr: string, limit = 2, span = DAY):Promise<boolean> {
+  async isValid (username: string, addr: string, limit = 1, span = DAY):Promise<boolean> {
     username = sha256(username);
     addr = sha256(addr);
 


### PR DESCRIPTION
closes #https://github.com/paritytech/substrate-matrix-faucet/issues/2

If you look at the faucet channel, you'll see that most users actually request twice a drip without a short time frame. If that was too quick, it results in https://github.com/paritytech/substrate-matrix-faucet/issues/2.

Making the UX better, and preventing the error, we now allow only 1 request per day, but get 2x more tokens :money_with_wings: 