### PR TITLE
Connect only when needed

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -62,7 +62,7 @@ bot.on('RoomMember.membership', (_, member: Record<string, string>) => {
   if (member.membership === 'invite' && member.userId === botUserId) {
     bot.joinRoom(member.roomId).then(() => {
       logger.info(`Auto-joined ${member.roomId}.`);
-    }).catch((e) => logger.error('Auto-join error', e));
+    }).catch((e) => logger.error('⭕ Auto-join error', e));
   }
 });
 
@@ -91,7 +91,7 @@ bot.on('Room.timeline', (event: mSDK.MatrixEvent) => {
       sendMessage(roomId, `The faucet has ${balance / 10 ** decimals} ${unit}s remaining.`);
     }).catch((e) => {
       sendMessage(roomId, 'An error occured, please check the server logs.');
-      logger.error('An error occured when checking the balance', e);
+      logger.error('⭕ An error occured when checking the balance', e);
     });
   } else if (action === '!drip') {
     try {
@@ -124,7 +124,7 @@ bot.on('Room.timeline', (event: mSDK.MatrixEvent) => {
       sendMessage(roomId, `Sent ${sender} ${dripAmount} ${unit}s. Extrinsic hash: ${res.data as string}`);
     }).catch((e) => {
       sendMessage(roomId, 'An unexpected error occured, please check the server logs');
-      logger.error('An error occured when dripping', e);
+      logger.error('⭕ An error occured when dripping', e);
     });
   } else if (action === '!help') {
     printHelpMessage(roomId);


### PR DESCRIPTION
closes #5
closes #39
closes https://github.com/paritytech/substrate-matrix-faucet/issues/3

This PR makes the bot work in such a way that it will connect to the WS endpoint right before doing something, and will then disconnect. This should prevent disconnection spam.. and faucet's unavailability :crossed_fingers: 

The api emits info about the WS connection being closed, after each token transfer like:
```
[2021-01-28T19:00:40.102] [INFO] default - Faucet backend listening on port 5555.
[2021-01-28T19:00:40.612] [INFO] default - 🤖 Beep bop - Creating the bot's account
[2021-01-28T19:00:52.700] [INFO] default - 💸 sending tokens
2021-01-28 19:00:56        RPC-CORE: subscribeStorage(keys?: Vec<StorageKey>): StorageChangeSet:: WebSocket is not connected
[2021-01-28T19:01:01.868] [INFO] default - 💸 sending tokens
2021-01-28 19:01:05        RPC-CORE: subscribeStorage(keys?: Vec<StorageKey>): StorageChangeSet:: WebSocket is not connected
```

it's somewhat expected, because at this time the WS connection has been closed (we indeed don't wait for the transfer to be effective before returning).