### PR TITLE
scrape metrics via "ServiceMonitor"

### DIFF
--- a/kubernetes/faucetbot/templates/service.yaml
+++ b/kubernetes/faucetbot/templates/service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.chain.name }}-service
+  labels:
+    {{- include "faucetbot.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.server.config.PORT }}
+      protocol: TCP
+  selector:
+    {{- include "faucetbot.selectorLabels" . | nindent 8 }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.chain.name }}-server-metrics
+spec:
+  selector:
+    matchLabels:
+    {{- include "faucetbot.selectorLabels" . | nindent 8 }}
+  endpoints:
+    - port: {{ .Values.server.config.PORT }}
+      interval: 15s
+---


### PR DESCRIPTION
* added a k8s *Service* on port :5555 to expose the prometheus exporter
* added a k8s *ServiceMonitor* so the enpoint can be picked up automatically 