### PR TITLE
ServiceMonitor endpoint must be type str

### DIFF
--- a/kubernetes/faucetbot/templates/service.yaml
+++ b/kubernetes/faucetbot/templates/service.yaml
@@ -8,6 +8,7 @@ spec:
   type: ClusterIP
   ports:
     - port: {{ .Values.server.config.PORT }}
+      name: metrics
       protocol: TCP
   selector:
     {{- include "faucetbot.selectorLabels" . | nindent 8 }}
@@ -21,6 +22,6 @@ spec:
     matchLabels:
     {{- include "faucetbot.selectorLabels" . | nindent 8 }}
   endpoints:
-    - port: {{ .Values.server.config.PORT }}
-      interval: 15s
+  - port: metrics
+    interval: 15s
 ---


### PR DESCRIPTION
fix for:  `spec.endpoints.port in body must be of type string:`
```
  matchLabels:
        app.kubernetes.io/name: faucetbot
        app.kubernetes.io/instance: canvas
  endpoints:
    - port: 5555
      interval: 15s
$ helm upgrade ${CI_ENVIRONMENT_NAME} kubernetes/faucetbot --install --namespace ${KUBE_NAMESPACE} --values kubernetes/faucetbot/${CI_ENVIRONMENT_NAME}-values.yaml --set server.secret.FAUCET_ACCOUNT_MNEMONIC="${FAUCET_ACCOUNT_MNEMONIC}" --set server.image.dockerTag="${DOCKER_TAG}" --set bot.secret.MATRIX_ACCESS_TOKEN="${MATRIX_ACCESS_TOKEN}" --set bot.image.dockerTag="${DOCKER_TAG}"
Error: UPGRADE FAILED: failed to create resource: ServiceMonitor.monitoring.coreos.com "canvas-server-metrics" is invalid: spec.endpoints.port: Invalid value: "integer": spec.endpoints.port in body must be of type string: "integer"
Cleaning up file based variables
00:00
ERROR: Job failed: command terminated with exit code 1
```