### PR TITLE
Query nonce to prevent low priority error

### DIFF
--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -68,7 +68,7 @@ export default class Actions {
 
       // start a counter and log a timeout error if we didn't get an answer in time
       const dripTimeout = rpcTimeout('drip');
-      const hash = await transfer.signAndSend(this.account);
+      const hash = await transfer.signAndSend(this.account, { nonce: -1 });
 
       // we got and answer reset the timeout
       clearTimeout(dripTimeout);


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate-matrix-faucet/issues/51

See: https://polkadot.js.org/docs/api/cookbook/tx/#how-do-i-take-the-pending-tx-pool-into-account-in-my-nonce