### PR TITLE
Add prometheus metrics (including faucet balance)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+build
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faucet",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
-    "backend": "yarn build && node ./build/server/index.js",
-    "bot": "yarn build && node ./build/bot/index.js",
+    "backend": "yarn build && node ./build/src/server/index.js",
+    "bot": "yarn build && node ./build/src/bot/index.js",
     "lint": "yarn build && npx eslint ./src/ --ext .js,.ts",
     "lint:fix": "yarn build && npx eslint ./src/ --ext .js,.ts --fix",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -54,8 +54,7 @@ export default class Actions {
   }
 
   /**
-   * Checks the current balance and updates the `faucetBalance` property.
-   * @returns
+   * This function checks the current balance and updates the `faucetBalance` property.
    */
   private async updateFaucetBalance () {
     if (!this.account) return;

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -42,7 +42,11 @@ export default class Actions {
       this.account = keyring.addFromMnemonic(mnemonic);
 
       // TODO: Adding a subscription would be better but the server supports on http for now
-      setInterval(() => { this.updateFaucetBalance() }, balancePollIntervalMs);
+      setInterval(() => {
+        // We do want the following to just start and run
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.updateFaucetBalance();
+      }, balancePollIntervalMs);
     }).catch((e) => {
       logger.error(e);
       errorCounter.plusOne('other');

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -45,7 +45,7 @@ export default class Actions {
       setInterval(() => {
         // We do want the following to just start and run
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.updateFaucetBalance();
+        this.updateFaucetBalance().catch(console.error);
       }, balancePollIntervalMs);
     }).catch((e) => {
       logger.error(e);

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -41,9 +41,8 @@ export default class Actions {
       const keyring = new Keyring({ type: 'sr25519' });
       this.account = keyring.addFromMnemonic(mnemonic);
 
-      // Adding a subscription would be better but the server supports on http for now
-      this.updateFaucetBalance();
-      const _faucetBalancePollingId = setInterval(this.updateFaucetBalance.bind(this), balancePollIntervalMs);
+      // TODO: Adding a subscription would be better but the server supports on http for now
+      setInterval(() => this.updateFaucetBalance.bind(this), balancePollIntervalMs);
     }).catch((e) => {
       logger.error(e);
       errorCounter.plusOne('other');
@@ -54,12 +53,12 @@ export default class Actions {
    * This function checks the current balance and updates the `faucetBalance` property.
    * @returns
    */
-  private async updateFaucetBalance() {
+  private async updateFaucetBalance () {
     const api = await this.getApiInstance();
     if (!this.account) return;
     const { data: balances } = await api.query.system.account(this.account.address);
     const precision = 5;
-    this.#faucetBalance = balances.free.toBn().div( new BN( 10 ** (decimals - precision))).toNumber()/ 10 ** precision;
+    this.#faucetBalance = balances.free.toBn().div(new BN(10 ** (decimals - precision))).toNumber() / 10 ** precision;
   }
 
   async getApiInstance (): Promise<ApiPromise> {
@@ -73,7 +72,7 @@ export default class Actions {
     return this.api;
   }
 
-  public getFaucetBalance() {
+  public getFaucetBalance (): number | undefined {
     return this.#faucetBalance;
   }
 

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -54,7 +54,7 @@ export default class Actions {
   }
 
   /**
-   * This function checks the current balance and updates the `faucetBalance` property.
+   * Checks the current balance and updates the `faucetBalance` property.
    * @returns
    */
   private async updateFaucetBalance () {

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -16,6 +16,7 @@ const mnemonic = getEnvVariable('FAUCET_ACCOUNT_MNEMONIC', envVars) as string;
 const url = getEnvVariable('RPC_ENDPOINT', envVars) as string;
 const injectedTypes = JSON.parse(getEnvVariable('INJECTED_TYPES', envVars) as string) as Record<string, string>;
 const decimals = getEnvVariable('NETWORK_DECIMALS', envVars) as number;
+const balancePollIntervalMs = 60000; // 1 minute
 
 const rpcTimeout = (service: string) => {
   const timeout = 10000;
@@ -41,7 +42,8 @@ export default class Actions {
       this.account = keyring.addFromMnemonic(mnemonic);
 
       // Adding a subscription would be better but the server supports on http for now
-      const _faucetBalancePollingId = setInterval(this.updateFaucetBalance.bind(this), 6000);
+      this.updateFaucetBalance();
+      const _faucetBalancePollingId = setInterval(this.updateFaucetBalance.bind(this), balancePollIntervalMs);
     }).catch((e) => {
       logger.error(e);
       errorCounter.plusOne('other');

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -42,7 +42,7 @@ export default class Actions {
       this.account = keyring.addFromMnemonic(mnemonic);
 
       // TODO: Adding a subscription would be better but the server supports on http for now
-      setInterval(() => this.updateFaucetBalance.bind(this), balancePollIntervalMs);
+      setInterval(() => { this.updateFaucetBalance() }, balancePollIntervalMs);
     }).catch((e) => {
       logger.error(e);
       errorCounter.plusOne('other');

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -58,8 +58,9 @@ export default class Actions {
    * @returns
    */
   private async updateFaucetBalance () {
-    const api = await this.getApiInstance();
     if (!this.account) return;
+    
+    const api = await this.getApiInstance();
     const { data: balances } = await api.query.system.account(this.account.address);
     const precision = 5;
     this.#faucetBalance = balances.free.toBn().div(new BN(10 ** (decimals - precision))).toNumber() / 10 ** precision;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -47,7 +47,7 @@ const createAndApplyActions = (): void => {
         logger.error(e);
         errorCounter.plusOne('other');
       })
-    ;
+      ;
   }
   );
 
@@ -55,8 +55,10 @@ const createAndApplyActions = (): void => {
     const { address, amount, sender } = req.body;
 
     storage.isValid(sender, address).then(async (isAllowed) => {
+      const privileged = sender.endsWith(':matrix.parity.io') || sender.endsWith(':web3.foundation');
+
       // parity member have unlimited access :)
-      if (!isAllowed && !sender.endsWith(':matrix.parity.io')) {
+      if (!isAllowed && !privileged) {
         res.send({ error: `${sender} has reached their daily quota. Only request once per day.` });
       } else {
         const sendTokensResult = await actions.sendTokens(address, amount);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -90,8 +90,7 @@ const createAndApplyActions = (): void => {
   app.post<unknown, DripResponse, BotRequestType>('/bot-endpoint', (req, res) => {
     const { address, amount, sender } = req.body;
     metrics.data.total_requests++;
-    console.log(metrics);
-    
+
     storage.isValid(sender, address).then(async (isAllowed) => {
       const privileged = sender.endsWith(':matrix.parity.io') || sender.endsWith(':web3.foundation');
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -30,7 +30,7 @@ const metrics: MetricsDefinition = {
 
 /**
  * Simplistic function to generate a prometheus metrics.
- * TODO: Switch to prom-client if this grows
+ * TODO: Switch to prom-client
  * @param name Name of the metric
  * @param type Type
  * @param value Value
@@ -40,11 +40,12 @@ const metrics: MetricsDefinition = {
  */
 function getMetrics (name: string, type: string, value: number | string | undefined, help = '', voidIfUndefined = false): string {
   if (!value && voidIfUndefined) return '';
+  const metrics_name = `${metrics.meta.prefix}_${name}`;
 
   let result = '';
-  if (help && help.length) result += `# HELP ${metrics.meta.prefix}_${name} ${help}\n`;
-  result += `# TYPE ${name} ${type}\n`;
-  result += `${name} ${value || 0}\n`;
+  if (help && help.length) result += `# HELP ${metrics_name} ${help}\n`;
+  result += `# TYPE ${metrics_name} ${type}\n`;
+  result += `${metrics_name} ${value || 0}\n`;
 
   return result;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,7 +1,7 @@
 import bodyParser from 'body-parser';
 import dotenv from 'dotenv';
 import express from 'express';
-import type { BalanceResponse, BotRequestType, DripResponse } from 'src/types';
+import type { BalanceResponse, BotRequestType, DripResponse, MetricsDefinition } from 'src/types';
 
 import { isDripSuccessResponse } from '../guards';
 import { checkEnvVariables, getEnvVariable, logger } from '../utils';
@@ -9,17 +9,52 @@ import Actions from './actions';
 import errorCounter from './ErrorCounter';
 import { envVars } from './serverEnvVars';
 import Storage from './storage';
+const pkg = require('../../package.json');
 
 dotenv.config();
 const storage = new Storage();
 const actions = new Actions();
+
+const metrics: MetricsDefinition = {
+  meta: {
+    prefix: 'faucet',
+  },
+  data: {
+    total_requests: 0,
+    success_requests: 0,
+    balance: 0,
+    errors_total: 0,
+    errors_rpc_timeout: 0,
+  }
+}
+
+/**
+ * Simplistic function to generate a prometheus metrics.
+ * TODO: Switch to prom-client if this grows
+ * @param name Name of the metric
+ * @param type Type
+ * @param value Value
+ * @param help Help test
+ * @param voidIfUndefined Whether we render it even if null/undefined
+ * @returns string
+ */
+function getMetrics(name: string, type: string,  value: number | string | undefined , help: string = '', voidIfUndefined: boolean = false): string {
+  if ( !value && voidIfUndefined ) return '';
+
+  let result = '';
+  if (help && help.length ) result += `# HELP ${metrics.meta.prefix}_${name} ${help}\n`;
+  result += `# TYPE ${name} ${type}\n`;
+  result += `${name} ${value}\n`;
+
+  return result;
+}
 
 const app = express();
 app.use(bodyParser.json());
 
 checkEnvVariables(envVars);
 
-const port = getEnvVariable('PORT', envVars) as string;
+const port = getEnvVariable('PORT', envVars) as number;
 
 app.get('/health', (_, res) => {
   res.send('Faucet backend is healthy.');
@@ -28,20 +63,15 @@ app.get('/health', (_, res) => {
 
 // prometheus metrics
 app.get('/metrics', (_, res) => {
-  let balanceMetric = '';
-  if (actions.getFaucetBalance()) {
-    balanceMetric += '# TYPE faucet_balance gauge\n';
-    balanceMetric += `faucet_balance ${actions.getFaucetBalance()}`;
-  }
-  res.end(`# HELP errors_total The total amount of errors logged on the faucet backend
-# TYPE errors_total counter
-errors_total ${errorCounter.total()}
-# HELP errors_rpc_timeout The total amount of timeout errors between the faucet backend and the rpc node
-# TYPE errors_rpc_timeout counter
-errors_rpc_timeout ${errorCounter.getValue('rpcTimeout')}
-${balanceMetric}
-`
-  );
+  let errors_total = getMetrics('errors_total', 'counter', errorCounter.total(), 'The total amount of errors logged on the faucet backend' );
+  let errors_rpc_timeout = getMetrics('errors_rpc_timeout', 'counter', errorCounter.getValue('rpcTimeout'), 'The total amount of timeout errors between the faucet backend and the rpc node' );
+
+  let balance = getMetrics('balance', 'gauge', actions.getFaucetBalance(), 'Current balance of the faucet', true );
+
+  let total_requests = getMetrics('total_requests', 'gauge', metrics.data.total_requests , 'Total number of requests to the faucet' );
+  let successful_requests = getMetrics('successful_requests', 'gauzge', metrics.data.success_requests, 'The total number of successful requests to the faucet' );
+
+  res.end(`${errors_total}${errors_rpc_timeout}${balance}${total_requests}${successful_requests}`);
 });
 
 const createAndApplyActions = (): void => {
@@ -59,7 +89,9 @@ const createAndApplyActions = (): void => {
 
   app.post<unknown, DripResponse, BotRequestType>('/bot-endpoint', (req, res) => {
     const { address, amount, sender } = req.body;
-
+    metrics.data.total_requests++;
+    console.log(metrics);
+    
     storage.isValid(sender, address).then(async (isAllowed) => {
       const privileged = sender.endsWith(':matrix.parity.io') || sender.endsWith(':web3.foundation');
 
@@ -71,6 +103,7 @@ const createAndApplyActions = (): void => {
 
         // hash is null if something wrong happened
         if (isDripSuccessResponse(sendTokensResult)) {
+          metrics.data.success_requests++;
           storage.saveData(sender, address)
             .catch((e) => {
               logger.error(e);
@@ -88,6 +121,7 @@ const createAndApplyActions = (): void => {
 };
 
 const main = () => {
+  logger.info(`Starting ${pkg.name} v${pkg.version}`);
   createAndApplyActions();
 
   app.listen(port, () => logger.info(`Faucet backend listening on port ${port}.`));

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export type EnvNameBot = 'BACKEND_URL'|
  'FAUCET_IGNORE_LIST'
 ;
 
-export interface MetricsDefinition  {
+export interface MetricsDefinition {
     meta: {
       prefix: string,
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,13 @@ export type EnvNameBot = 'BACKEND_URL'|
  'FAUCET_IGNORE_LIST'
 ;
 
+export interface MetricsDefinition  {
+    meta: {
+      prefix: string,
+    },
+    data: { [id: string] : number }
+}
+
 export interface EnvOpt {
   default?: PrimitivType;
   required: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,16 +49,16 @@ export function checkEnvVariables <T extends EnvNameBot | EnvNameServer> (envVar
         if (!opt.default) {
           console.error(`✖︎ No default value set for optionnal variable ${env}`);
         } else {
-          console.log(`◉ Optionnal environment variable ${env} not set, using default (${opt.default.toString()}).`);
+          logger.info(`◉ Optionnal environment variable ${env} not set, using default (${opt.default.toString()}).`);
         }
       }
     } else {
       if (opt.secret) {
-        console.log(`✓ ${env} it set (secret)`);
+        logger.info(`✓ ${env} it set (secret)`);
       } else {
-        console.log(`✓ ${env} set to ${value}`);
+        logger.info(`✓ ${env} set to ${value}`);
       }
     }
   });
-  console.log('------------------------------------------');
+  logger.info('------------------------------------------');
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
       // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
       // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
       // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-  
+
       /* Strict Type-Checking Options */
       "strict": true,                           /* Enable all strict type-checking options. */
       // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
@@ -34,13 +34,13 @@
       // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
       // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
       // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-  
+
       /* Additional Checks */
       // "noUnusedLocals": true,                /* Report errors on unused locals. */
       // "noUnusedParameters": true,            /* Report errors on unused parameters. */
       // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
       // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-  
+
       /* Module Resolution Options */
       "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
       "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
@@ -55,21 +55,23 @@
       "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
       // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
       // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-  
+
       /* Source Map Options */
       // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
       // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
       // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
       // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-  
+
       /* Experimental Options */
       // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
       // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-  
+
       /* Advanced Options */
       "forceConsistentCasingInFileNames": true, /* Disallow inconsistently-cased references to the same file. */
       "skipLibCheck": true,                     /* Skip checking .d.ts files for errors */
-      "pretty": true
+      "pretty": true,
+
+      "resolveJsonModule": true,
     },
     "include": [
       "./src/**/*"


### PR DESCRIPTION
This PR adds new Prometheus metrics:
- balance
- total_requests
- successful_requests

It also does:
- remove all the console.log and switch to using the logger
- log the version at start
- bump the server version
- ⚠️ move previous metrics to the new `faucet_` namespace (see example below) 

The goal was not to rewrite too much code so the following is left for other PRs:
- #80 
- #82 

```
# HELP faucet_errors_total The total amount of errors logged on the faucet backend
# TYPE faucet_errors_total counter
faucet_errors_total 0
# HELP faucet_errors_rpc_timeout The total amount of timeout errors between the faucet backend and the rpc node
# TYPE faucet_errors_rpc_timeout counter
faucet_errors_rpc_timeout 0
# HELP faucet_balance Current balance of the faucet
# TYPE faucet_balance gauge
faucet_balance 8.36929
# HELP faucet_total_requests Total number of requests to the faucet
# TYPE faucet_total_requests gauge
faucet_total_requests 0
# HELP faucet_successful_requests The total number of successful requests to the faucet
# TYPE faucet_successful_requests gauzge
faucet_successful_requests 0
```

fix #67 