### PR TITLE
Threshold limit on the amount the faucet can dispense to an account

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Setup a .env file with the following variables
 ```bash
 
 FAUCET_ACCOUNT_MNEMONIC #required - mnemonic seed from faucet account
+FAUCET_BALANCE_CAP # optional - Upper limit cap on whether or not the account can recieve more tokens. Defaults to 100.
 INJECTED_TYPES #optional - if any type must be overriden
 NETWORK_DECIMALS #optional - decimal amount for the network
 PORT #optional - the port you want the server to listen on
@@ -34,6 +35,7 @@ RPC_ENDPOINT #optional - required - ws rpc node endpoint
 example:
 ```bash
 FAUCET_ACCOUNT_MNEMONIC="this is a fake mnemonic"
+FAUCET_BALANCE_CAP=100
 INJECTED_TYPES="{ "Address": "AccountId", "LookupSource": "AccountId" }"
 NETWORK_DECIMALS=12
 PORT=5555

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -84,27 +84,16 @@ export default class Actions {
     return scaledBalanceFree;
   }
 
-  async sendTokens(
-    address: string,
-    amount: string,
-    isPrivileged: boolean
-  ): Promise<DripResponse> {
+  public async isAccountOverBalanceCap(address: string): Promise<boolean> {
+    return (await this.getAccountBalance(address)) > balanceCap;
+  }
+
+  async sendTokens(address: string, amount: string): Promise<DripResponse> {
     let dripTimeout: ReturnType<typeof rpcTimeout> | null = null;
     let result: DripResponse;
 
     try {
       if (!this.account) throw new Error('account not ready');
-
-      const accountBalance = await this.getAccountBalance(address);
-      const isAccountOverBalanceCap = accountBalance > balanceCap;
-
-      if (!isPrivileged && isAccountOverBalanceCap) {
-        logger.error(
-          `⭕ Blocking faucet as this account balance is over the threshold limit of ${balanceCap}`
-        );
-
-        throw Error('Account balance is over the faucet threshold');
-      }
 
       const dripAmount = Number(amount) * 10 ** decimals;
 

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -81,7 +81,7 @@ export default class Actions {
       const { data } = await apiInstance.query.system.account(address);
       const { free: balanceFree } = data;
       const scaledBalanceFree =
-        balanceFree.toBn().toNumber() / Math.pow(10, decimals);
+        balanceFree.toBn().div(10 ** decimals).toNumber();
 
       if (scaledBalanceFree > balanceCap) {
         logger.error(

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -162,18 +162,22 @@ const createAndApplyActions = (): void => {
         .isValid(sender, address)
         .then(async (isAllowed) => {
           const isPrivileged = isAccountPrivlidged(sender);
+          const isAccountOverBalanceCap = await actions.isAccountOverBalanceCap(
+            address
+          );
 
           // parity member have unlimited access :)
+
           if (!isAllowed && !isPrivileged) {
             res.send({
               error: `${sender} has reached their daily quota. Only request once per day.`,
             });
+          } else if (isAllowed && isAccountOverBalanceCap && !isPrivileged) {
+            res.send({
+              error: `${sender}'s balance is over the faucet threshold`,
+            });
           } else {
-            const sendTokensResult = await actions.sendTokens(
-              address,
-              amount,
-              isPrivileged
-            );
+            const sendTokensResult = await actions.sendTokens(address, amount);
 
             // hash is null if something wrong happened
             if (isDripSuccessResponse(sendTokensResult)) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -11,7 +11,12 @@ import type {
   DripResponse,
   MetricsDefinition,
 } from '../types';
-import { checkEnvVariables, getEnvVariable, logger } from '../utils';
+import {
+  checkEnvVariables,
+  getEnvVariable,
+  isAccountPrivlidged,
+  logger,
+} from '../utils';
 import Actions from './actions';
 import errorCounter from './ErrorCounter';
 import apiInstance from './rpc';
@@ -156,9 +161,7 @@ const createAndApplyActions = (): void => {
       storage
         .isValid(sender, address)
         .then(async (isAllowed) => {
-          const isPrivileged =
-            sender.endsWith(':matrix.parity.io') ||
-            sender.endsWith(':web3.foundation');
+          const isPrivileged = isAccountPrivlidged(sender);
 
           // parity member have unlimited access :)
           if (!isAllowed && !isPrivileged) {
@@ -166,7 +169,11 @@ const createAndApplyActions = (): void => {
               error: `${sender} has reached their daily quota. Only request once per day.`,
             });
           } else {
-            const sendTokensResult = await actions.sendTokens(address, amount);
+            const sendTokensResult = await actions.sendTokens(
+              address,
+              amount,
+              isPrivileged
+            );
 
             // hash is null if something wrong happened
             if (isDripSuccessResponse(sendTokensResult)) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -173,7 +173,7 @@ const createAndApplyActions = (): void => {
             });
           } else if (isAllowed && isAccountOverBalanceCap && !isPrivileged) {
             res.send({
-              error: `${sender}'s balance is over the faucet threshold`,
+              error: `${sender}'s balance is over the faucet's balance cap`,
             });
           } else {
             const sendTokensResult = await actions.sendTokens(address, amount);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -167,7 +167,6 @@ const createAndApplyActions = (): void => {
           );
 
           // parity member have unlimited access :)
-
           if (!isAllowed && !isPrivileged) {
             res.send({
               error: `${sender} has reached their daily quota. Only request once per day.`,

--- a/src/server/serverEnvVars.ts
+++ b/src/server/serverEnvVars.ts
@@ -2,6 +2,12 @@ import { EnvNameServer, EnvVar } from '../types';
 
 export const envVars: EnvVar<EnvNameServer> = {
   FAUCET_ACCOUNT_MNEMONIC: { required: true, secret: true, type: 'string' },
+  FAUCET_BALANCE_CAP: {
+    default: 100,
+    required: false,
+    secret: false,
+    type: 'number',
+  },
   INJECTED_TYPES: {
     default: '{}',
     required: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type PrimitivType = string | number | boolean;
 
 export type EnvNameServer =
   | 'FAUCET_ACCOUNT_MNEMONIC'
+  | 'FAUCET_BALANCE_CAP'
   | 'INJECTED_TYPES'
   | 'NETWORK_DECIMALS'
   | 'PORT'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,3 +77,9 @@ export function checkEnvVariables<T extends EnvNameBot | EnvNameServer>(
   });
   logger.info('------------------------------------------');
 }
+
+export function isAccountPrivlidged(sender: string): boolean {
+  return (
+    sender.endsWith(':matrix.parity.io') || sender.endsWith(':web3.foundation')
+  );
+}


### PR DESCRIPTION
Fixes #70 

I've defaulted this to `100` but let me know if you prefer another limit