### PR TITLE
Reverting changes made where we moved the ApiProvider instance

### DIFF
--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -1,6 +1,7 @@
+import { ApiPromise } from '@polkadot/api';
 import { Keyring } from '@polkadot/keyring';
 import { KeyringPair } from '@polkadot/keyring/types';
-import { waitReady } from '@polkadot/wasm-crypto';
+import { HttpProvider } from '@polkadot/rpc-provider';
 import BN from 'bn.js';
 
 import { DripResponse } from '../types';
@@ -10,6 +11,10 @@ import apiInstance from './rpc';
 import { envVars } from './serverEnvVars';
 
 const mnemonic = getEnvVariable('FAUCET_ACCOUNT_MNEMONIC', envVars) as string;
+const url = getEnvVariable('RPC_ENDPOINT', envVars) as string;
+const injectedTypes = JSON.parse(
+  getEnvVariable('INJECTED_TYPES', envVars) as string
+) as Record<string, string>;
 const decimals = getEnvVariable('NETWORK_DECIMALS', envVars) as number;
 const balanceCap = getEnvVariable('FAUCET_BALANCE_CAP', envVars) as number;
 const balancePollIntervalMs = 60000; // 1 minute
@@ -24,16 +29,18 @@ const rpcTimeout = (service: string) => {
 };
 
 export default class Actions {
+  api: ApiPromise | undefined;
   account: KeyringPair | undefined;
   #faucetBalance: number | undefined;
 
   constructor() {
-    logger.info("🤖 Beep bop - Creating the bot's account");
+    this.getApiInstance()
+      .then(() => {
+        logger.info("🤖 Beep bop - Creating the bot's account");
 
-    try {
-      const keyring = new Keyring({ type: 'sr25519' });
-
-      waitReady().then(() => {
+        // once the api is initialized, we can create and account
+        // if we don't wait we'll get an error "@polkadot/wasm-crypto has not been initialized"
+        const keyring = new Keyring({ type: 'sr25519' });
         this.account = keyring.addFromMnemonic(mnemonic);
 
         setInterval(() => {
@@ -42,11 +49,11 @@ export default class Actions {
           // TODO: Adding a subscription would be better but the server supports on http for now
           this.updateFaucetBalance().catch(console.error);
         }, balancePollIntervalMs);
+      })
+      .catch((e) => {
+        logger.error(e);
+        errorCounter.plusOne('other');
       });
-    } catch (error) {
-      logger.error(error);
-      errorCounter.plusOne('other');
-    }
   }
 
   /**
@@ -55,7 +62,8 @@ export default class Actions {
   private async updateFaucetBalance() {
     if (!this.account) return;
 
-    const { data: balances } = await apiInstance.query.system.account(
+    const api = await this.getApiInstance();
+    const { data: balances } = await api.query.system.account(
       this.account.address
     );
     const precision = 5;
@@ -65,6 +73,26 @@ export default class Actions {
         .div(new BN(10 ** (decimals - precision)))
         .toNumber() /
       10 ** precision;
+  }
+
+  async getApiInstance(): Promise<ApiPromise> {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      try {
+        if (!this.api) {
+          logger.info('Creating new api instance');
+          this.api = new ApiPromise({
+            provider: new HttpProvider(url),
+            types: injectedTypes,
+          });
+        }
+
+        return await this.api.isReady;
+      } catch (e) {
+        logger.error('⭕ An error occured when getting api instance', e);
+        this.api = undefined;
+      }
+    }
   }
 
   public getFaucetBalance(): number | undefined {
@@ -96,12 +124,13 @@ export default class Actions {
       if (!this.account) throw new Error('account not ready');
 
       const dripAmount = Number(amount) * 10 ** decimals;
+      const api = await this.getApiInstance();
 
       logger.info('💸 sending tokens');
 
       // start a counter and log a timeout error if we didn't get an answer in time
       dripTimeout = rpcTimeout('drip');
-      const transfer = apiInstance.tx.balances.transfer(address, dripAmount);
+      const transfer = api.tx.balances.transfer(address, dripAmount);
       const hash = await transfer.signAndSend(this.account, { nonce: -1 });
       result = { hash: hash.toHex() };
     } catch (e) {
@@ -120,6 +149,8 @@ export default class Actions {
 
   async getBalance(): Promise<string> {
     try {
+      const api = await this.getApiInstance();
+
       if (!this.account) {
         throw new Error('account not ready');
       }
@@ -129,7 +160,7 @@ export default class Actions {
       // start a counter and log a timeout error if we didn't get an answer in time
       const balanceTimeout = rpcTimeout('balance');
 
-      const { data: balances } = await apiInstance.query.system.account(
+      const { data: balances } = await api.query.system.account(
         this.account.address
       );
 


### PR DESCRIPTION
This is a revert PR of https://github.com/paritytech/substrate-matrix-faucet/pull/94/files to test with.

It should give us some insight into what exactly is causing the error shown in Grafana

```
2021-11-19 13:30:49 |  
-- | --
  |   | 2021-11-19 13:30:49 | at processTicksAndRejections (node:internal/process/task_queues:96:5)
  |   | 2021-11-19 13:30:49 | at ApiPromise.value (/backend/node_modules/@polkadot/api/base/Init.cjs:88:25)
  |   | 2021-11-19 13:30:49 | Error: FATAL: Unable to initialize the API: Cannot convert undefined or null to object
  |   | 2021-11-19 13:30:49 |  
  |   | 2021-11-19 13:30:49 | ^
  |   | 2021-11-19 13:30:49 | triggerUncaughtException(err, true /* fromPromise */);
  |   | 2021-11-19 13:30:49 | node:internal/process/promises:246
  |   | 2021-11-19 13:30:49 | at processTicksAndRejections (node:internal/process/task_queues:96:5)
  |   | 2021-11-19 13:30:49 | at ApiPromise.value (/backend/node_modules/@polkadot/api/base/Init.cjs:88:25)
  |   | 2021-11-19 13:30:49 | 2021-11-19 03:00:49        API/INIT: Error: FATAL: Unable to initialize the API: Cannot convert undefined or null to object
```