### PR TITLE
Finish the request handling in the case of an error

### DIFF
--- a/src/server/routes/actions.ts
+++ b/src/server/routes/actions.ts
@@ -19,6 +19,7 @@ router.get<unknown, BalanceResponse>("/balance", (_, res) => {
     .catch((e) => {
       logger.error(e);
       errorCounter.plusOne("other");
+      res.send({ balance: "0" });
     });
 });
 
@@ -55,6 +56,7 @@ router.post<unknown, DripResponse, BotRequestType>("/bot-endpoint", (req, res) =
     .catch((e) => {
       logger.error(e);
       errorCounter.plusOne("other");
+      res.send({ error: "Operation failed." });
     });
 });
 


### PR DESCRIPTION
Just a tiny change that finishes handling the request in the event of an error.
Otherwise, the request hangs forever, as tested locally with `curl`.