### PR TITLE
Propose a new, externally accessible faucet endpoint

### DIFF
--- a/docker/docker-compose.rococo-external.yml
+++ b/docker/docker-compose.rococo-external.yml
@@ -1,0 +1,11 @@
+services:
+  faucet-server:
+    extends:
+      file: docker-compose.yml
+      service: faucet-server
+    ports:
+      - "${SMF_BACKEND_PORT}:${SMF_BACKEND_PORT}"
+    environment:
+      SMF_BACKEND_NETWORK_DECIMALS: 12
+      SMF_BACKEND_RPC_ENDPOINT: "https://rococo-rpc.polkadot.io/"
+      SMF_BACKEND_EXTERNAL_ACCESS: true

--- a/env.server.config.json
+++ b/env.server.config.json
@@ -44,7 +44,7 @@
       },
       "EXTERNAL_ACCESS": {
         "description": "Whether the backend should serve external drip requests. Disables the bot endpoint.",
-        "default": false,
+        "default": "false",
         "type": "boolean"
       }
     }

--- a/env.server.config.json
+++ b/env.server.config.json
@@ -41,6 +41,11 @@
         "description": "time when we deployed app backend",
         "default": "unset",
         "type": "string"
+      },
+      "EXTERNAL_ACCESS": {
+        "description": "Whether the backend should serve external drip requests. Disables the bot endpoint.",
+        "default": false,
+        "type": "boolean"
       }
     }
   }

--- a/src/faucetConfig.ts
+++ b/src/faucetConfig.ts
@@ -4,7 +4,13 @@ import botConfigSpec from "../env.bot.config.json";
 import serverConfigSpec from "../env.server.config.json";
 import { logger } from "./logger";
 
-type SpecType<T> = T extends { type: "string" } ? string : T extends { type: "number" } ? number : never;
+type SpecType<T> = T extends { type: "string" }
+  ? string
+  : T extends { type: "number" }
+  ? number
+  : T extends { type: "boolean" }
+  ? boolean
+  : never;
 
 export function faucetBotConfig() {
   const config = faucetConfig("bot");

--- a/src/server/routes/actions.ts
+++ b/src/server/routes/actions.ts
@@ -27,7 +27,7 @@ const dripRequestHandler = async (requestOpts: DripRequestType): Promise<DripRes
   const { address, parachain_id, amount, sender } = requestOpts;
   metricsDefinition.data.total_requests++;
 
-  const isAllowed = await storage.isValid(sender, address);
+  const isAllowed = await storage.isValid({ username: sender, addr: address });
   const isPrivileged = isAccountPrivileged(sender);
   const isAccountOverBalanceCap = await actions.isAccountOverBalanceCap(address);
 
@@ -42,7 +42,7 @@ const dripRequestHandler = async (requestOpts: DripRequestType): Promise<DripRes
     // hash is null if something wrong happened
     if (isDripSuccessResponse(sendTokensResult)) {
       metricsDefinition.data.success_requests++;
-      storage.saveData(sender, address).catch((e) => {
+      storage.saveData({ username: sender, addr: address }).catch((e) => {
         logger.error(e);
         errorCounter.plusOne("other");
       });

--- a/src/server/services/ActionStorage.spec.ts
+++ b/src/server/services/ActionStorage.spec.ts
@@ -77,7 +77,7 @@ for (const dp of dataProvider) {
       }
 
       if (dp.save) {
-        await storage.saveData(dp.save.username, dp.save.addr);
+        await storage.saveData({ username: dp.save.username, addr: dp.save.addr });
       }
 
       // un-fake system date to real time
@@ -85,7 +85,7 @@ for (const dp of dataProvider) {
         jest.useRealTimers();
       }
 
-      expect(await storage.isValid(dp.expect.username, dp.expect.addr)).toBe(dp.expect.isValid);
+      expect(await storage.isValid({ username: dp.expect.username, addr: dp.expect.addr })).toBe(dp.expect.isValid);
     });
   });
 }


### PR DESCRIPTION
This PR proposes a new `/drip` endpoint, which could be externally accessible for the users, as requested by https://github.com/paritytech/opstooling/issues/172

It introduces a new configuration option `EXTERNAL_ACCESS`. If it's disabled, there should be no changes to the behaviour of the backend. It is disabled by default.

If it's enabled, it creates a new endpoint which is rate-limited by IP address of the requester.

The PR also introduces a new `docker-compose` file which can be used to spin up a new, seperate faucet with separate funds. That way, we require no changes to existing faucets - they can continue to not expose any ports and any risks would be limited to this new deployment of the faucet.

### What would be next

If we decide to continue going this way, I would be adding changes such us [request sanitization](https://github.com/paritytech/substrate-matrix-faucet/pull/187) or limiting daily total limit of faucet payouts.
In this PR I tried to make minimum viable changes.

Also I would think about resetting the IP limit more frequently, e.g. once per hour. Because if two developers would be trying to drip on the same wifi they wouldn't be able to for the whole day.