### PR TITLE
Optimize docker image (re)builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,10 @@
-build
-node_modules
+# Exclude all:
+*
+
+# Include what is actually used:
+!package.json
+!yarn.lock
+!tsconfig.json
+!env.bot.config.json
+!env.server.config.json
+!src

--- a/bot_injected.Dockerfile
+++ b/bot_injected.Dockerfile
@@ -24,6 +24,6 @@ COPY ./package.json ./yarn.lock ./
 RUN yarn --network-concurrency 1 --frozen-lockfile
 
 COPY . .
-RUN yarn prepare && yarn build
+RUN yarn build
 
 CMD yarn start:bot

--- a/bot_injected.Dockerfile
+++ b/bot_injected.Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/library/node:16.10-alpine
 
 # uncomment to fix build on MacOS Apple Silicon chip
-RUN apk add --no-cache python3 make g++
+# RUN apk add --no-cache python3 make g++
 
 RUN apk add git==2.30.6-r0
 

--- a/bot_injected.Dockerfile
+++ b/bot_injected.Dockerfile
@@ -2,7 +2,6 @@ FROM docker.io/library/node:16.10-alpine
 
 # uncomment to fix build on MacOS Apple Silicon chip
 # RUN apk add --no-cache python3 make g++
-
 RUN apk add git==2.30.6-r0
 
 ARG VCS_REF=master

--- a/bot_injected.Dockerfile
+++ b/bot_injected.Dockerfile
@@ -1,5 +1,10 @@
 FROM docker.io/library/node:16.10-alpine
 
+# uncomment to fix build on MacOS Apple Silicon chip
+RUN apk add --no-cache python3 make g++
+
+RUN apk add git==2.30.6-r0
+
 ARG VCS_REF=master
 ARG BUILD_DATE=""
 ARG REGISTRY_PATH=docker.io/paritytech
@@ -15,9 +20,12 @@ LABEL io.parity.image.authors="cicd-team@parity.io" \
     io.parity.image.created="${BUILD_DATE}"
 
 WORKDIR /bot
+
+COPY ./package.json .
+COPY ./yarn.lock .
+RUN yarn --network-concurrency 1 --frozen-lockfile
+
 COPY . .
-# uncomment to fix build on MacOS Apple Silicon chip
-# RUN apk add --no-cache python3 make g++
-RUN apk add git==2.30.6-r0
-RUN yarn --network-concurrency 1 --frozen-lockfile && yarn build
+RUN yarn prepare && yarn build
+
 CMD yarn start:bot

--- a/bot_injected.Dockerfile
+++ b/bot_injected.Dockerfile
@@ -20,8 +20,7 @@ LABEL io.parity.image.authors="cicd-team@parity.io" \
 
 WORKDIR /bot
 
-COPY ./package.json .
-COPY ./yarn.lock .
+COPY ./package.json ./yarn.lock ./
 RUN yarn --network-concurrency 1 --frozen-lockfile
 
 COPY . .

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "prepare": "yarn generate:types",
+    "prebuild": "yarn generate:types",
     "generate:types": "echo \"declare const schema: $(cat env.server.config.json); export default schema;\" > env.server.config.json.d.ts && echo \"declare const schema: $(cat env.bot.config.json); export default schema;\" > env.bot.config.json.d.ts",
     "build": "tsc",
     "start:backend": "node ./build/src/server/index.js",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "postinstall": "yarn generate:types",
     "prebuild": "yarn generate:types",
     "generate:types": "echo \"declare const schema: $(cat env.server.config.json); export default schema;\" > env.server.config.json.d.ts && echo \"declare const schema: $(cat env.bot.config.json); export default schema;\" > env.bot.config.json.d.ts",
     "build": "tsc",

--- a/server_injected.Dockerfile
+++ b/server_injected.Dockerfile
@@ -26,5 +26,4 @@ RUN yarn --network-concurrency 1 --frozen-lockfile
 COPY . .
 RUN yarn build
 
-RUN yarn --network-concurrency 1 --frozen-lockfile && yarn build
 CMD yarn start:backend

--- a/server_injected.Dockerfile
+++ b/server_injected.Dockerfile
@@ -20,8 +20,7 @@ LABEL io.parity.image.authors="cicd-team@parity.io" \
 
 WORKDIR /backend
 
-COPY ./package.json .
-COPY ./yarn.lock .
+COPY ./package.json ./yarn.lock ./
 RUN yarn --network-concurrency 1 --frozen-lockfile
 
 COPY . .

--- a/server_injected.Dockerfile
+++ b/server_injected.Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/library/node:16.10-alpine
 
 # uncomment to fix build on MacOS Apple Silicon chip
-RUN apk add --no-cache python3 make g++
+# RUN apk add --no-cache python3 make g++
 
 RUN apk add git==2.30.6-r0
 

--- a/server_injected.Dockerfile
+++ b/server_injected.Dockerfile
@@ -2,7 +2,6 @@ FROM docker.io/library/node:16.10-alpine
 
 # uncomment to fix build on MacOS Apple Silicon chip
 # RUN apk add --no-cache python3 make g++
-
 RUN apk add git==2.30.6-r0
 
 ARG VCS_REF=master

--- a/server_injected.Dockerfile
+++ b/server_injected.Dockerfile
@@ -24,7 +24,7 @@ COPY ./package.json ./yarn.lock ./
 RUN yarn --network-concurrency 1 --frozen-lockfile
 
 COPY . .
-RUN yarn prepare && yarn build
+RUN yarn build
 
 RUN yarn --network-concurrency 1 --frozen-lockfile && yarn build
 CMD yarn start:backend


### PR DESCRIPTION
Some optimization mechanics for the docker images - very useful when changing the code and rebuilding the images.

## Dockerfiles

1. Move the `apk add` commands to top - so that this layer can be cached between code changes
2. Split the step of `yarn install`, so that the layer with `node_modules` can be cached between code changes

## Dockerignore

There are a lot of unnecessary stuff in the docker build context:

```bash
./README.md
./server_injected.Dockerfile
./tsconfig.json
./jest.config.js
./env.server.config.json
./.eslintignore
./env.bot.config.json
./.prettierignore
./nodemon.json
./bot_injected.Dockerfile
./.eslintrc.cjs
./.idea
./.idea/workspace.xml
./.idea/modules.xml
./.idea/.gitignore
./.idea/optimize-faucet.iml
./.idea/vcs.xml
./.gitlab-ci.yml
./yarn.lock
./src
./src/faucetConfig.ts
./src/logger.ts
./src/utils.ts
./src/server
./src/server/config.ts
./src/server/constants.ts
./src/server/routes
./src/server/routes/healthcheck.ts
./src/server/routes/metrics.ts
./src/server/routes/actions.ts
./src/server/utils.ts
./src/server/router.ts
./src/server/utils.spec.ts
./src/server/services
./src/server/services/DripRequestHandler.ts
./src/server/services/Recaptcha.ts
./src/server/services/ActionStorage.spec.ts
./src/server/services/Actions.ts
./src/server/services/Recaptcha.spec.ts
./src/server/services/ErrorCounter.ts
./src/server/services/ActionStorage.ts
./src/server/services/DripRequestHandler.spec.ts
./src/server/polkadotApi.ts
./src/server/index.ts
./src/faucet.e2e.ts
./src/guards.ts
./src/utils.spec.ts
./src/bot
./src/bot/index.ts
./src/types.ts
./CODEOWNERS
./docker
./docker/docker-compose.rococo.yml
./docker/docker-compose.westend.yml
./docker/docker-compose.versi.yml
./docker/docker-compose.yml
./docker/docker-compose.rococo-external.yml
./e2e
./e2e/matrix_data
./e2e/matrix_data/localhost.log.config
./e2e/matrix_data/homeserver.yaml
./e2e/matrix_data/.gitignore
./e2e/matrix_data/localhost.signing.mockkey
./e2e/wait_until.sh
./e2e/docker-compose.yml
./e2e/bootstrap.sh
./.editorconfig
./kubernetes
./kubernetes/rococo-values.yaml
./kubernetes/rococo-external-values.yaml
./kubernetes/westend-values.yaml
./.gitignore
./package.json
./.prettierrc.cjs
./.dockerignore
./Dockerfile.build-context
./.github
./.github/workflows
./.github/workflows/E2E.yml
./jest.e2e.config.js
./.env.example
./.git
./.git/hooks
./.git/hooks/pre-applypatch.sample
./.git/hooks/applypatch-msg.sample
./.git/hooks/pre-rebase.sample
./.git/hooks/fsmonitor-watchman.sample
./.git/hooks/pre-merge-commit.sample
./.git/hooks/pre-commit.sample
./.git/hooks/push-to-checkout.sample
./.git/hooks/prepare-commit-msg.sample
./.git/hooks/post-update.sample
./.git/hooks/pre-push.sample
./.git/hooks/commit-msg.sample
./.git/hooks/pre-receive.sample
./.git/hooks/update.sample
./.git/description
./.git/info
./.git/info/exclude
./.git/HEAD
./.git/index
./.git/objects
./.git/objects/info
./.git/objects/pack
./.git/objects/pack/pack-b1da18ccc15d6000e6f7f9b53066574597954d68.idx
./.git/objects/pack/pack-b1da18ccc15d6000e6f7f9b53066574597954d68.pack
./.git/refs
./.git/refs/heads
./.git/refs/heads/main
./.git/refs/heads/rzadp
./.git/refs/heads/rzadp/optimize-docker
./.git/refs/tags
./.git/refs/remotes
./.git/refs/remotes/origin
./.git/refs/remotes/origin/HEAD
./.git/logs
./.git/logs/HEAD
./.git/logs/refs
./.git/logs/refs/heads
./.git/logs/refs/heads/main
./.git/logs/refs/heads/rzadp
./.git/logs/refs/heads/rzadp/optimize-docker
./.git/logs/refs/remotes
./.git/logs/refs/remotes/origin
./.git/logs/refs/remotes/origin/HEAD
./.git/config
./.git/packed-refs
./.git/FETCH_HEAD
```

The problem with this is that any change to any of those files, even if it is not related to typescript code, causes the `COPY . . => yarn build` layers to be invalidated.

I went with the extremist approach of excluding everything and then including what is needed - but I don't have a strong preference to this approach.