### PR TITLE
Divided endpoints based on faucet or drip bot

### DIFF
--- a/src/server/routes/actions.ts
+++ b/src/server/routes/actions.ts
@@ -33,7 +33,10 @@ router.get<unknown, BalanceResponse>("/balance", (_, res) => {
     });
 });
 
-const missingParameterError = (res: Response<DripErrorResponse>, parameter: keyof BotDripRequestType | keyof FaucetRequestType): void => {
+const missingParameterError = (
+  res: Response<DripErrorResponse>,
+  parameter: keyof BotDripRequestType | keyof FaucetRequestType,
+): void => {
   res.status(400).send({ error: `Missing parameter: '${parameter}'` });
 };
 

--- a/src/server/routes/actions.ts
+++ b/src/server/routes/actions.ts
@@ -33,7 +33,7 @@ router.get<unknown, BalanceResponse>("/balance", (_, res) => {
     });
 });
 
-const missingParameterError = (res: Response<DripErrorResponse>, parameter: string): void => {
+const missingParameterError = (res: Response<DripErrorResponse>, parameter: keyof BotDripRequestType | keyof FaucetRequestType): void => {
   res.status(400).send({ error: `Missing parameter: '${parameter}'` });
 };
 

--- a/src/server/routes/actions.ts
+++ b/src/server/routes/actions.ts
@@ -105,13 +105,11 @@ router.post<unknown, DripResponse, Partial<DripRequestType>>("/drip", async (req
   try {
     const { address, parachain_id, amount, sender, recaptcha } = req.body;
     if (!address) {
-      res.send({ error: "Missing parameter: 'address'" });
-      return;
+      return missingParameterError(res, "address");
     }
     if (config.Get("EXTERNAL_ACCESS")) {
       if (!recaptcha) {
-        res.send({ error: "Missing parameter: 'recaptcha'" });
-        return;
+        return missingParameterError(res, "recaptcha");
       }
       res.send(
         await dripRequestHandler.handleRequest({
@@ -124,12 +122,10 @@ router.post<unknown, DripResponse, Partial<DripRequestType>>("/drip", async (req
       );
     } else {
       if (!amount) {
-        res.send({ error: "Missing parameter: 'amount'" });
-        return;
+        return missingParameterError(res, "amount");
       }
       if (!sender) {
-        res.send({ error: "Missing parameter: 'sender'" });
-        return;
+        return missingParameterError(res, "sender");
       }
       res.send(
         await dripRequestHandler.handleRequest({

--- a/src/server/routes/actions.ts
+++ b/src/server/routes/actions.ts
@@ -80,6 +80,10 @@ router.post<unknown, DripResponse, FaucetRequestType>("/drip/web", addressMiddle
 });
 
 router.post<unknown, DripResponse, BotDripRequestType>("/drip/bot", addressMiddleware, async (req, res) => {
+  // Do not allow this endpoint to be accessed from outside. Should only be for the bot
+  if (config.Get("EXTERNAL_ACCESS")) {
+    return res.status(503).send({ error: "Endpoint unavailable" });
+  }
   const { address, parachain_id, amount, sender } = req.body;
   if (!amount) {
     return missingParameterError(res, "amount");

--- a/src/server/routes/actions.ts
+++ b/src/server/routes/actions.ts
@@ -33,14 +33,16 @@ router.get<unknown, BalanceResponse>("/balance", (_, res) => {
     });
 });
 
+const missingParameterError = (res: Response, parameter: string): void =>
+  res.status(400).send({ error: `Missing parameter: '${parameter}'` });
+
 const addressMiddleware = (
   req: Request<unknown, DripResponse, Partial<DripRequestType>>,
   res: Response,
   next: NextFunction,
 ): void => {
   if (!req.body.address) {
-    res.status(400).send({ error: "Missing parameter: 'address'" });
-    return;
+    return missingParameterError(res, "address");
   }
   next();
 };
@@ -50,8 +52,7 @@ const dripRequestHandler = new DripRequestHandler(actions, storage, recaptchaSer
 router.post<unknown, DripResponse, FaucetRequestType>("/faucet", addressMiddleware, async (req, res) => {
   const { address, parachain_id, recaptcha } = req.body;
   if (!recaptcha) {
-    res.status(400).send({ error: "Missing parameter: 'recaptcha'" });
-    return;
+    return missingParameterError(res, "recaptcha");
   }
   try {
     const dripResult = await dripRequestHandler.handleRequest({
@@ -77,12 +78,10 @@ router.post<unknown, DripResponse, FaucetRequestType>("/faucet", addressMiddlewa
 router.post<unknown, DripResponse, BotDripRequestType>("/drip-v2", addressMiddleware, async (req, res) => {
   const { address, parachain_id, amount, sender } = req.body;
   if (!amount) {
-    res.status(400).send({ error: "Missing parameter: 'amount'" });
-    return;
+    return missingParameterError(res, "amount");
   }
   if (!sender) {
-    res.status(400).send({ error: "Missing parameter: 'sender'" });
-    return;
+    return missingParameterError(res, "sender");
   }
   try {
     res.send(

--- a/src/server/routes/actions.ts
+++ b/src/server/routes/actions.ts
@@ -53,7 +53,7 @@ const addressMiddleware = (
 
 const dripRequestHandler = new DripRequestHandler(actions, storage, recaptchaService);
 
-router.post<unknown, DripResponse, FaucetRequestType>("/faucet", addressMiddleware, async (req, res) => {
+router.post<unknown, DripResponse, FaucetRequestType>("/drip/web", addressMiddleware, async (req, res) => {
   const { address, parachain_id, recaptcha } = req.body;
   if (!recaptcha) {
     return missingParameterError(res, "recaptcha");
@@ -79,7 +79,7 @@ router.post<unknown, DripResponse, FaucetRequestType>("/faucet", addressMiddlewa
   }
 });
 
-router.post<unknown, DripResponse, BotDripRequestType>("/drip-v2", addressMiddleware, async (req, res) => {
+router.post<unknown, DripResponse, BotDripRequestType>("/drip/bot", addressMiddleware, async (req, res) => {
   const { address, parachain_id, amount, sender } = req.body;
   if (!amount) {
     return missingParameterError(res, "amount");

--- a/src/server/routes/actions.ts
+++ b/src/server/routes/actions.ts
@@ -33,8 +33,9 @@ router.get<unknown, BalanceResponse>("/balance", (_, res) => {
     });
 });
 
-const missingParameterError = (res: Response, parameter: string): void =>
+const missingParameterError = (res: Response<DripErrorResponse>, parameter: string): void => {
   res.status(400).send({ error: `Missing parameter: '${parameter}'` });
+};
 
 const addressMiddleware = (
   req: Request<unknown, DripResponse, Partial<DripRequestType>>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export interface DripRequestType {
   recaptcha?: string;
 }
 
-export interface BotDripRequestType {
+export interface BotRequestType {
   address: string;
   amount: string;
   parachain_id: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,3 +42,16 @@ export interface DripRequestType {
   sender?: string;
   recaptcha?: string;
 }
+
+export interface BotDripRequestType {
+  address: string;
+  amount: string;
+  parachain_id: string;
+  sender?: string;
+}
+
+export interface FaucetRequestType {
+  address: string;
+  parachain_id: string;
+  recaptcha?: string;
+}


### PR DESCRIPTION
This PR tries to divide the endpoints into two different methods.

It adds a couple of improvements to reduce duplicated code.

# Endpoints

It created the following endpoints:
- `faucet/`
- `drip-v2/`

I kept the default drip endpoint to not break the already existing implementation, but if `drip-v2` works, we could replace `drip` with that one.

The `faucet` endpoint only handles the expected values coming from the faucet clients (!ink docs and the web faucet) while the drip endpoint handles the other part of the requests.

This way we remove ifs from the code and can also isolate the endpoints.

It adds a couple of improvements to reduce duplicated code.

## Middleware

```typescript
const addressMiddleware = (
  req: Request<unknown, DripResponse, Partial<DripRequestType>>,
  res: Response,
  next: NextFunction,
): void => {
  if (!req.body.address) {
    return missingParameterError(res, "address");
  }
  next();
};
```

It creates this middleware to ensure that the field address is not empty.

## Status code in errors

As the current implementation doesn't return an error status code, I add them so the system can show an error on the request. I also added HTTP codes based on the type of errors.

```typescript
res.status(400).send({ error: "Operation failed." });
```

## Missing field error

I simplified the code of a missing variable into a method that is void (so it can be returned too)
```typescript
const missingParameterError = (res: Response<DripErrorResponse>, parameter: string): void => {
  res.status(400).send({ error: `Missing parameter: '${parameter}'` });
};
```
