### PR TITLE
added number pattern to parachain input

### DIFF
--- a/client/src/lib/Form.svelte
+++ b/client/src/lib/Form.svelte
@@ -52,7 +52,7 @@
     <div class="form-control w-full max-w-xs col-span-2">
       <input disabled={!useParachain} bind:value={network}
              type="number" placeholder={useParachain ? "Parachain id" : "Using Relay chain"}
-             min="1000" max="9999"
+             min="1000" max="9999" pattern="\d*"
              class="input input-bordered input-primary w-full max-w-xs"/>
     </div>
   </div>


### PR DESCRIPTION
Added the field `pattern="\d*"` to the network input which, on phones, brings up the numeric keyboard instead of the regular keyboard.

Just a very small QoL improvement.