### PR TITLE
updated faucet to work with ink-docs server faucet

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -27,9 +27,8 @@ jobs:
       - run: yarn run check
       - run: yarn run build
         env:
-          VITE_CAPTCHA_KEY: 6Ldlmp8kAAAAACEOROGslrJ7gUZjmJIm6WBPUVki
+          VITE_CAPTCHA_KEY: 6LdU5kckAAAAANktvvAKJ0auYUBRP0su94G7WXwe
           VITE_FAUCET_URL: https://ink-docs-rococo-faucet.parity-testnet.parity.io/drip/web
-          VITE_DEMO: true
       - uses: actions/upload-artifact@master
         with:
           name: faucet


### PR DESCRIPTION
Google captcha credential has been authorized to work in the paritytech.github.io domain.

This commit will enable the correct captcha key for that endpoint and allow the faucet to contact the server.