### PR TITLE
E2E: Add a parachain, and test asset teleportation

### DIFF
--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -9,8 +9,8 @@ jobs:
   e2e:
     strategy:
       matrix:
-        a: [1,2,3,4,5,6]
-        b: [1,2,3,4,5,6]
+        a: [1,2,3,4]
+        b: [1,2,3,4]
       max-parallel: 4
     timeout-minutes: 15
     runs-on: ubuntu-22.04

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -4,14 +4,8 @@ on:
   push:
     branches:
       - main
-      - rzadp/teleport-test
 jobs:
   e2e:
-    strategy:
-      matrix:
-        a: [1,2,3,4,5]
-        b: [1,2,3,4,5]
-      max-parallel: 4
     timeout-minutes: 15
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -18,16 +18,18 @@ jobs:
           node-version: "16.10"
       - name: Download Polkadot and parachain binaries
         run: |
-          wget https://github.com/paritytech/cumulus/releases/download/v0.9.380/polkadot-parachain
-          wget https://github.com/paritytech/polkadot/releases/download/v0.9.38/polkadot
+          wget --no-verbose https://github.com/paritytech/cumulus/releases/download/v0.9.380/polkadot-parachain
+          wget --no-verbose https://github.com/paritytech/polkadot/releases/download/v0.9.38/polkadot
           chmod +x ./polkadot*
         working-directory: e2e
       - name: Run a local relaychain with a parachain using zombienet
         run: |
           export PATH=$(pwd):$PATH
-          npx --yes @zombienet/cli@1.3.40 --provider native spawn zombienet.native.toml
+          npx --yes @zombienet/cli@1.3.40 \
+            --provider native spawn zombienet.native.toml \
+            > polkadot.txt 2>&1 &
         working-directory: e2e
-      - name: Bootstrap Polkadot and Matrix
+      - name: Bootstrap Matrix
         run: |
           chmod -R o+rwx ./e2e/matrix_data
           ./e2e/bootstrap.sh
@@ -37,6 +39,9 @@ jobs:
           ./e2e/wait_until.sh 'curl -s "127.0.0.1:5555"'
       - name: Run the E2E tests
         run: yarn test:e2e
+      - name: Debug Polkadot logs
+        if: failure()
+        run: cat e2e/polkadot.txt
       - name: Debug Matrix logs
         if: failure()
         run: docker-compose -f e2e/docker-compose.infrastructure.yml logs matrix

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -29,6 +29,8 @@ jobs:
           npx --yes @zombienet/cli@1.3.40 \
             --provider native spawn zombienet.native.toml \
             > polkadot.txt 2>&1 &
+          source wait_until.sh 'curl -s "127.0.0.1:9933"'
+          source wait_until.sh 'curl -s "127.0.0.1:9934"'
         working-directory: e2e
       - name: Bootstrap Matrix
         run: |

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-node@v3.5.1
         with:
           node-version: "16.10"
+      - run: yarn install --network-concurrency 1 --frozen-lockfile
       - name: Download Polkadot and parachain binaries
         run: |
           wget --no-verbose https://github.com/paritytech/cumulus/releases/download/v0.9.380/polkadot-parachain

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -9,8 +9,8 @@ jobs:
   e2e:
     strategy:
       matrix:
-        a: [1,2,3,4]
-        b: [1,2,3,4]
+        a: [1,2,3,4,5]
+        b: [1,2,3,4,5]
       max-parallel: 4
     timeout-minutes: 15
     runs-on: ubuntu-22.04

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - rzadp/teleport-test
 jobs:
   e2e:
     timeout-minutes: 15

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -16,7 +16,17 @@ jobs:
         uses: actions/setup-node@v3.5.1
         with:
           node-version: "16.10"
-      - run: yarn install --network-concurrency 1 --frozen-lockfile
+      - name: Download Polkadot and parachain binaries
+        run: |
+          wget https://github.com/paritytech/cumulus/releases/download/v0.9.380/polkadot-parachain
+          wget https://github.com/paritytech/polkadot/releases/download/v0.9.38/polkadot
+          chmod +x ./polkadot*
+        working-directory: e2e
+      - name: Run a local relaychain with a parachain using zombienet
+        run: |
+          export PATH=$(pwd):$PATH
+          npx --yes @zombienet/cli@1.3.40 --provider native spawn zombienet.native.toml
+        working-directory: e2e
       - name: Bootstrap Polkadot and Matrix
         run: |
           chmod -R o+rwx ./e2e/matrix_data
@@ -27,9 +37,6 @@ jobs:
           ./e2e/wait_until.sh 'curl -s "127.0.0.1:5555"'
       - name: Run the E2E tests
         run: yarn test:e2e
-      - name: Debug Polkadot logs
-        if: failure()
-        run: docker-compose -f e2e/docker-compose.infrastructure.yml logs polkadot
       - name: Debug Matrix logs
         if: failure()
         run: docker-compose -f e2e/docker-compose.infrastructure.yml logs matrix

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -7,6 +7,11 @@ on:
       - rzadp/teleport-test
 jobs:
   e2e:
+    strategy:
+      matrix:
+        a: [1,2,3,4,5,6]
+        b: [1,2,3,4,5,6]
+      max-parallel: 4
     timeout-minutes: 15
     runs-on: ubuntu-22.04
 

--- a/e2e/bootstrap.sh
+++ b/e2e/bootstrap.sh
@@ -9,7 +9,7 @@ rm -rf ./matrix_data/homeserver.db* ../sqlite.db
 docker network rm faucet-e2e || true
 
 
-# Wait until Polkadot with a parachain are up.
+# Make sure Polkadot with a parachain are up.
 # They should be started before running this script.
 source wait_until.sh 'curl -s "127.0.0.1:9933"'
 source wait_until.sh 'curl -s "127.0.0.1:9934"'

--- a/e2e/bootstrap.sh
+++ b/e2e/bootstrap.sh
@@ -9,11 +9,16 @@ rm -rf ./matrix_data/homeserver.db* ../sqlite.db
 docker network rm faucet-e2e || true
 
 
-# Start Polkadot and Matrix and wait until they are up.
+# Wait until Polkadot with a parachain are up.
+# They should be started before running this script.
+source wait_until.sh 'curl -s "127.0.0.1:9933"'
+source wait_until.sh 'curl -s "127.0.0.1:9934"'
+
+
+# Start Matrix and wait until it is up.
 docker network create faucet-e2e
 docker-compose -f docker-compose.infrastructure.yml up -d
 source wait_until.sh 'curl -s "127.0.0.1:8008"'
-source wait_until.sh 'curl -s "127.0.0.1:9933"'
 
 
 # Generate users:
@@ -63,7 +68,8 @@ SMF_BACKEND_FAUCET_BALANCE_CAP=100
 SMF_BACKEND_INJECTED_TYPES="{ \"Address\": \"AccountId\", \"LookupSource\": \"AccountId\" }"
 SMF_BACKEND_NETWORK_DECIMALS=12
 SMF_BACKEND_PORT=5555
-SMF_BACKEND_RPC_ENDPOINT="http://polkadot:9933/"
+# Local Zombienet relaychain node.
+SMF_BACKEND_RPC_ENDPOINT="http://host.docker.internal:9933/"
 SMF_BACKEND_DEPLOYED_REF=local
 SMF_BACKEND_DEPLOYED_TIME=local
 SMF_BACKEND_EXTERNAL_ACCESS=true

--- a/e2e/docker-compose.deployment.yml
+++ b/e2e/docker-compose.deployment.yml
@@ -12,3 +12,5 @@ services:
       - ./.env
     networks:
       - faucet-e2e
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/e2e/docker-compose.infrastructure.yml
+++ b/e2e/docker-compose.infrastructure.yml
@@ -2,15 +2,6 @@ networks:
   faucet-e2e:
     external: true
 services:
-  polkadot:
-    container_name: e2e-polkadot
-    image: parity/polkadot:v0.9.39
-    platform: linux/x86_64
-    ports:
-      - "9933:9933"
-    networks:
-      - faucet-e2e
-    command: "--dev --ws-external --rpc-external"
   matrix:
     container_name: e2e-matrix
     image: matrixdotorg/synapse:v1.76.0

--- a/e2e/zombienet.native.toml
+++ b/e2e/zombienet.native.toml
@@ -1,0 +1,23 @@
+[relaychain]
+default_command = "polkadot"
+default_args = [ "-lparachain=debug" ]
+
+chain = "rococo-local"
+
+  [[relaychain.nodes]]
+  name = "alice"
+  validator = true
+  ws_port = 9933
+
+  [[relaychain.nodes]]
+  name = "bob"
+  validator = true
+
+[[parachains]]
+id = 100
+
+  [parachains.collator]
+  name = "alice"
+  ws_port = 9934
+  command = "polkadot-parachain"
+  args = ["-lparachain=debug"]

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -4,5 +4,5 @@ const commonConfig = require("./jest.config")
 module.exports = {
   ...commonConfig,
   testMatch: [ "**/?(*.)+(e2e).[jt]s?(x)" ],
-  testTimeout: 10_000
+  testTimeout: 40_000
 };

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -4,5 +4,5 @@ const commonConfig = require("./jest.config")
 module.exports = {
   ...commonConfig,
   testMatch: [ "**/?(*.)+(e2e).[jt]s?(x)" ],
-  testTimeout: 40_000
+  testTimeout: 60_000
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "format:fix": "prettier ./src --write",
     "fix": "yarn lint:fix && yarn format:fix",
     "test": "jest",
-    "test:e2e": "NODE_OPTIONS='--experimental-vm-modules --es-module-specifier-resolution=node' jest -c jest.e2e.config.js"
+    "test:e2e": "NODE_OPTIONS='--experimental-vm-modules --es-module-specifier-resolution=node' jest -c jest.e2e.config.js --runInBand"
   },
   "author": "",
   "license": "ISC",

--- a/src/faucet.e2e.ts
+++ b/src/faucet.e2e.ts
@@ -72,7 +72,7 @@ describe("Faucet E2E", () => {
     expect(botMessage.body).toMatch(/^The faucet has (999.*|100.*) UNITs remaining.$/);
   });
 
-  test("The bots drips to a given address", async () => {
+  test("The bot drips to a given address", async () => {
     const userAddress = randomAddress();
     const initialBalance = await getUserBalance(userAddress);
 
@@ -83,7 +83,7 @@ describe("Faucet E2E", () => {
     expect(botMessage.body).toContain("Sent @user:parity.io 10 UNITs.");
     await until(
       async () => (await getUserBalance(userAddress)).gt(initialBalance),
-      500,
+      1000,
       15,
       "balance did not increase.",
     );

--- a/src/faucet.e2e.ts
+++ b/src/faucet.e2e.ts
@@ -135,7 +135,11 @@ describe("Faucet E2E", () => {
     const userAddress = randomAddress();
     const initialBalance = await getUserBalance(userAddress, parachainApi);
 
-    const result = await webEndpoint.post("/drip/web", { address: userAddress, recaptcha: "anything goes", parachain_id: "100" });
+    const result = await webEndpoint.post("/drip/web", {
+      address: userAddress,
+      recaptcha: "anything goes",
+      parachain_id: "100",
+    });
 
     expect(result.status).toEqual(200);
     expect("hash" in result.data).toBeTruthy();

--- a/src/faucet.e2e.ts
+++ b/src/faucet.e2e.ts
@@ -89,7 +89,7 @@ describe("Faucet E2E", () => {
     );
   });
 
-  test("The bots teleports to a given address", async () => {
+  test("The bot teleports to a given address", async () => {
     const userAddress = randomAddress();
     const initialBalance = await getUserBalance(userAddress, parachainApi);
 
@@ -127,6 +127,22 @@ describe("Faucet E2E", () => {
       async () => (await getUserBalance(userAddress)).gt(initialBalance),
       500,
       15,
+      "balance did not increase.",
+    );
+  });
+
+  test("The web endpoint teleports to a given address", async () => {
+    const userAddress = randomAddress();
+    const initialBalance = await getUserBalance(userAddress, parachainApi);
+
+    const result = await webEndpoint.post("/drip/web", { address: userAddress, recaptcha: "anything goes", parachain_id: "100" });
+
+    expect(result.status).toEqual(200);
+    expect("hash" in result.data).toBeTruthy();
+    await until(
+      async () => (await getUserBalance(userAddress, parachainApi)).gt(initialBalance),
+      1000,
+      30,
       "balance did not increase.",
     );
   });

--- a/src/faucet.e2e.ts
+++ b/src/faucet.e2e.ts
@@ -102,7 +102,7 @@ describe("Faucet E2E", () => {
     await until(
       async () => (await getUserBalance(userAddress, parachainApi)).gt(initialBalance),
       1000,
-      30,
+      40,
       "balance did not increase.",
     );
   });
@@ -146,7 +146,7 @@ describe("Faucet E2E", () => {
     await until(
       async () => (await getUserBalance(userAddress, parachainApi)).gt(initialBalance),
       1000,
-      30,
+      40,
       "balance did not increase.",
     );
   });


### PR DESCRIPTION
- Change current way of running polkadot to zombienet, in order to add a parachain
- Properly test asset teleportation
- Change the tests so they no longer assert balance of `0` at the beginning, so they no longer fail when re-run
- Add some missing tests, such as checking balance via web endpoint
- Closes https://github.com/paritytech/substrate-matrix-faucet/issues/231
- Closes https://github.com/paritytech/substrate-matrix-faucet/issues/212
- I've run this on CI multiple times to check flakiness. To me it seems non-flaky enough for this kind of test, but it's not at a 100% success rate.